### PR TITLE
Don't ignore raised exceptions in events

### DIFF
--- a/hiven/util.py
+++ b/hiven/util.py
@@ -1,4 +1,4 @@
 import traceback
 
 def format_exception(e: Exception) -> str:
-     return "".join(traceback.format_exception(type(e), e, e.__traceback__, 4)).replace("```", "｀｀｀")
+     return "".join(traceback.format_exception(type(e), e, e.__traceback__, 4))

--- a/hiven/util.py
+++ b/hiven/util.py
@@ -1,0 +1,4 @@
+import traceback
+
+def format_exception(e: Exception) -> str:
+     return "".join(traceback.format_exception(type(e), e, e.__traceback__, 4)).replace("```", "｀｀｀")


### PR DESCRIPTION
This PR adds basic error handling for exceptions raised from events dispatched from `Client.dispatch_event(...)`. It nicely prints the exceptions out, along with information on where it came from.